### PR TITLE
Finished gnn arch. Building md module

### DIFF
--- a/moml/models/mgnn/djmgnn.py
+++ b/moml/models/mgnn/djmgnn.py
@@ -388,7 +388,7 @@ class DJMGNN(nn.Module):
         current_edge_index, current_edge_attr = self.drop_edges(current_edge_index, current_edge_attr)
 
         h_intermediate, outs = current_x, []
-        for block in enumerate(self.blocks):
+        for block in self.blocks:
             if h_intermediate.numel() == 0:
                 block_output_dim = block.transition.out_features if hasattr(block, "transition") else self.hidden_dim
                 h_intermediate = torch.empty(0, block_output_dim).to(x.device)

--- a/moml/models/mgnn/djmgnn.py
+++ b/moml/models/mgnn/djmgnn.py
@@ -208,8 +208,11 @@ class DJMGNN(nn.Module):
         use_supernode=True,
         use_rbf=True,
         rbf_K=32,
+        env_dim: int = 0,
+        env_mlp: bool = False,
     ):
         super().__init__()
+        self.env_dim = env_dim
         self.p_dropedge, self.use_super, self.use_rbf, self.rbf_K = p_dropedge, use_supernode, use_rbf, rbf_K
         self.hidden_dim = hidden_dim  # Cache the hidden dimension
         self.node_out_dim = node_out_dim  # Store the node output dimension
@@ -236,14 +239,25 @@ class DJMGNN(nn.Module):
 
         self.jk = JKAggregator([hidden_dim] * n_blocks, hidden_dim, mode=jk_mode)
 
+        # optional env projection
+        env_in = env_dim if not env_mlp else hidden_dim
+        if env_dim and env_mlp:
+            self.env_proj = nn.Sequential(nn.Linear(env_dim, hidden_dim), nn.SiLU())
+        else:
+            self.env_proj = None
+
+        fused_graph_in = hidden_dim + env_in
+        fused_node_in = hidden_dim + env_in
+
+        # heads
         self.node_head = nn.Sequential(
-            nn.Linear(hidden_dim, hidden_dim // 2),
+            nn.Linear(fused_node_in, hidden_dim // 2),
             nn.ReLU(),
             nn.Dropout(dropout),
             nn.Linear(hidden_dim // 2, node_out_dim),
         )
         self.graph_head = nn.Sequential(
-            nn.Linear(hidden_dim, hidden_dim // 2),
+            nn.Linear(fused_graph_in, hidden_dim // 2),
             nn.ReLU(),
             nn.Dropout(dropout),
             nn.Linear(hidden_dim // 2, graph_out_dim),
@@ -325,7 +339,7 @@ class DJMGNN(nn.Module):
         mask = torch.rand(edge_index.size(1), device=edge_index.device) > self.p_dropedge
         return edge_index[:, mask], (edge_attr[mask] if edge_attr is not None and edge_attr.numel() > 0 else edge_attr)
 
-    def forward(self, x, edge_index, edge_attr=None, batch=None, dist=None):
+    def forward(self, x, edge_index, edge_attr=None, batch=None, dist=None, env_vec=None):
         if x.numel() == 0:
             # logger.warning("DJMGNN forward called with zero nodes.")
             return {
@@ -374,7 +388,7 @@ class DJMGNN(nn.Module):
         current_edge_index, current_edge_attr = self.drop_edges(current_edge_index, current_edge_attr)
 
         h_intermediate, outs = current_x, []
-        for block_idx, block in enumerate(self.blocks):
+        for block in enumerate(self.blocks):
             if h_intermediate.numel() == 0:
                 block_output_dim = block.transition.out_features if hasattr(block, "transition") else self.hidden_dim
                 h_intermediate = torch.empty(0, block_output_dim).to(x.device)
@@ -403,5 +417,14 @@ class DJMGNN(nn.Module):
         else:
             graph_pooled = self.pool(h_aggregated, current_batch)
 
-        graph_pred = self.graph_head(graph_pooled)
+        if self.env_dim:
+            if env_vec is None:
+                env_vec = x.new_zeros(graph_pooled.size(0), self.env_dim)
+            env_emb = self.env_proj(env_vec) if self.env_proj else env_vec
+            graph_fused = torch.cat([graph_pooled, env_emb], 1)
+            h_aggregated = torch.cat([h_aggregated, env_emb], 1)
+        else:
+            graph_fused = graph_pooled
+        graph_pred = self.graph_head(graph_fused)
+        # If graph_pred is empty, ensure it's the right size
         return {"node_pred": node_pred, "graph_pred": graph_pred}

--- a/moml/models/mgnn/hmgnn.py
+++ b/moml/models/mgnn/hmgnn.py
@@ -196,6 +196,8 @@ class HMGNN(nn.Module):
         self,
         scale_dims: List[int],
         hidden_dim: int = 64,
+        env_dim: int = 0,
+        env_mlp: bool = False,
         n_blocks: int = 2,
         layers_per_block: int = 3,
         edge_attr_dims: Optional[List[int]] = None,
@@ -234,6 +236,15 @@ class HMGNN(nn.Module):
         if cross_scale_exchange:
             self.cross_scale = CrossScaleAttentionMH(self.S, hidden_dim, n_heads_cs, edge_dim_cs)
 
+        # env projection
+        env_in = env_dim if not env_mlp else hidden_dim
+        if env_dim and env_mlp:
+            self.env_proj = nn.Sequential(nn.Linear(env_dim, hidden_dim), nn.SiLU())
+        else:
+            self.env_proj = None
+
+        fused_dim = hidden_dim + env_in
+
         # heads
         self.node_heads = nn.ModuleList(
             [
@@ -251,7 +262,7 @@ class HMGNN(nn.Module):
         self.graph_heads = nn.ModuleList(
             [
                 nn.Sequential(
-                    nn.Linear(hidden_dim, hidden_dim // 2),
+                    nn.Linear(fused_dim, hidden_dim // 2),
                     nn.ReLU(),
                     nn.Dropout(dropout),
                     nn.Linear(hidden_dim // 2, graph_out_dim),
@@ -260,7 +271,7 @@ class HMGNN(nn.Module):
             ]
         )
         self.combined_graph_head = nn.Sequential(
-            nn.Linear(hidden_dim * self.S, hidden_dim),
+            nn.Linear(fused_dim * self.S, hidden_dim),
             nn.ReLU(),
             nn.Dropout(dropout),
             nn.Linear(hidden_dim, graph_out_dim),
@@ -275,6 +286,7 @@ class HMGNN(nn.Module):
         scale_data: List[Dict[str, Any]],
         maps: Optional[Tuple[List[torch.Tensor], List[torch.Tensor]]] = None,
         edge_pairs_cs: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        env_vec: Optional[torch.Tensor] = None,
     ) -> Dict[str, Any]:
         """
         scale_data[i] = {'x', 'edge_index', 'edge_attr'?, 'batch'?, 'mask'?}
@@ -329,8 +341,12 @@ class HMGNN(nn.Module):
                     if batch_vec is None
                     else self.graph_pool(current_scale_node_feats, batch_vec)
                 )
+                if self.env_dim:
+                    if env_vec is None:
+                        env_vec = x.new_zeros(g_emb.size(0), self.env_dim)
+                    env_emb = self.env_proj(env_vec) if self.env_proj else env_vec
+                    g_emb = torch.cat([g_emb, env_emb], dim=1)
                 current_graph_pred = self.graph_heads[i](g_emb)
-
             graph_embeds.append(g_emb)
             graph_preds.append(current_graph_pred)
             output_dict[f"scale_{i}_graph_pred"] = current_graph_pred

--- a/moml/simulation/molecular_dynamics/force_field_mapper.py
+++ b/moml/simulation/molecular_dynamics/force_field_mapper.py
@@ -2,8 +2,7 @@
 Force Field Parameter Mapper Module
 
 This module provides functionality to convert machine learning predictions
-(from MGNN models) into force field parameters for molecular dynamics simulations.
-It supports multiple force field formats and simulation engines.
+(from MGNN models) into force field parameters for OpenMM molecular dynamics simulations.
 """
 
 import os
@@ -18,52 +17,27 @@ from rdkit.Chem import AllChem
 # Get module logger
 logger = logging.getLogger("force_field_mapper")
 
-# Supported force field formats
-SUPPORTED_FF_FORMATS = ["amber", "gaff", "charmm", "opls", "gromos"]
-
-# Supported simulation engines
-SUPPORTED_ENGINES = ["gromacs", "amber", "openmm", "lammps", "namd"]
-
 
 class ForceFieldMapper:
     """
-    Converts ML model predictions to force field parameters for MD simulations.
+    Converts ML model predictions to force field parameters for OpenMM MD simulations.
 
     This class provides methods to:
     1. Map node-level predictions (e.g., partial charges) to atoms
-    2. Convert predictions to various force field format files
+    2. Convert predictions to OpenMM XML force field format
     3. Validate parameter quality
-    4. Export to different MD simulation engines
     """
 
     def __init__(
         self,
-        force_field_type: str = "amber",
-        simulation_engine: str = "gromacs",
         config: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the ForceFieldMapper.
 
         Args:
-            force_field_type: Type of force field to generate (amber, gaff, charmm, etc.)
-            simulation_engine: Target simulation engine (gromacs, amber, openmm, etc.)
             config: Additional configuration parameters
         """
-        # Validate and set force field type
-        if force_field_type.lower() not in SUPPORTED_FF_FORMATS:
-            logger.warning(f"Force field type '{force_field_type}' not in supported formats: {SUPPORTED_FF_FORMATS}")
-            logger.info("Defaulting to 'amber' force field type.")  # Added logger.info
-            force_field_type = "amber"
-        self.force_field_type = force_field_type.lower()
-
-        # Validate and set simulation engine
-        if simulation_engine.lower() not in SUPPORTED_ENGINES:
-            logger.warning(f"Simulation engine '{simulation_engine}' not in supported engines: {SUPPORTED_ENGINES}")
-            logger.info("Defaulting to 'gromacs' simulation engine.")  # Added logger.info
-            simulation_engine = "gromacs"
-        self.simulation_engine = simulation_engine.lower()
-
         # Store configuration
         self.config = config or {}
 
@@ -107,95 +81,71 @@ class ForceFieldMapper:
 
         return charge_map
 
-    def assign_atom_types(self, mol: Chem.Mol, force_field_type: Optional[str] = None) -> Dict[int, str]:
+    def assign_atom_types(self, mol: Chem.Mol) -> Dict[int, str]:
         """
-        Assign atom types based on the selected force field.
+        Assign atom types based on element and hybridization.
 
         Args:
             mol: RDKit molecule
-            force_field_type: Type of force field to use for atom typing
 
         Returns:
             Dictionary mapping atom indices to atom types
         """
-        # Use instance force field type if not specified
-        if force_field_type is None:
-            force_field_type = self.force_field_type
-
         atom_types = {}
 
-        if force_field_type == "gaff" or force_field_type == "amber":
-            # For GAFF/AMBER, we would normally use AmberTools
-            # This is a simplified implementation using RDKit's properties
-            for i, atom in enumerate(mol.GetAtoms()):
-                element = atom.GetSymbol()
-                hyb = atom.GetHybridization()
-                is_aromatic = atom.GetIsAromatic()
+        for i, atom in enumerate(mol.GetAtoms()):
+            element = atom.GetSymbol()
+            hyb = atom.GetHybridization()
+            is_aromatic = atom.GetIsAromatic()
 
-                # Very simplified GAFF-like atom typing
-                if element == "C":
-                    if is_aromatic:
-                        atype = "ca"  # Aromatic carbon
-                    elif hyb == Chem.rdchem.HybridizationType.SP3:
-                        atype = "c3"  # SP3 carbon
-                    elif hyb == Chem.rdchem.HybridizationType.SP2:
-                        atype = "c2"  # SP2 carbon
-                    elif hyb == Chem.rdchem.HybridizationType.SP:
-                        atype = "c1"  # SP carbon
-                    else:
-                        atype = "c3"  # Default
-                elif element == "N":
-                    if is_aromatic:
-                        atype = "na"  # Aromatic nitrogen
-                    elif hyb == Chem.rdchem.HybridizationType.SP3:
-                        atype = "n3"  # SP3 nitrogen
-                    elif hyb == Chem.rdchem.HybridizationType.SP2:
-                        atype = "n2"  # SP2 nitrogen
-                    elif hyb == Chem.rdchem.HybridizationType.SP:
-                        atype = "n1"  # SP nitrogen
-                    else:
-                        atype = "n3"  # Default
-                elif element == "O":
-                    if hyb == Chem.rdchem.HybridizationType.SP3:
-                        atype = "oh"  # Hydroxyl oxygen
-                    elif hyb == Chem.rdchem.HybridizationType.SP2:
-                        atype = "o"  # Carbonyl oxygen
-                    else:
-                        atype = "o"  # Default
-                elif element == "F":
-                    atype = "f"  # Fluorine
-                elif element == "H":
-                    # Check what the hydrogen is bonded to
-                    neighbors = [n.GetSymbol() for n in atom.GetNeighbors()]
-                    if "C" in neighbors:
-                        atype = "hc"  # H attached to C
-                    elif "N" in neighbors:
-                        atype = "hn"  # H attached to N
-                    elif "O" in neighbors:
-                        atype = "ho"  # H attached to O
-                    else:
-                        atype = "h1"  # Default hydrogen
-                else:
-                    # For other elements, use lowercase symbol as type
-                    atype = element.lower()
-
-                atom_types[i] = atype
-        else:
-            # For other force fields, use generic atom type based on element and hybridization
-            for i, atom in enumerate(mol.GetAtoms()):
-                element = atom.GetSymbol()
-                hyb = atom.GetHybridization()
-
-                if hyb == Chem.rdchem.HybridizationType.SP3:
-                    hyb_str = "3"
+            # Generate atom type based on element and hybridization
+            if element == "C":
+                if is_aromatic:
+                    atype = "ca"  # Aromatic carbon
+                elif hyb == Chem.rdchem.HybridizationType.SP3:
+                    atype = "c3"  # SP3 carbon
                 elif hyb == Chem.rdchem.HybridizationType.SP2:
-                    hyb_str = "2"
+                    atype = "c2"  # SP2 carbon
                 elif hyb == Chem.rdchem.HybridizationType.SP:
-                    hyb_str = "1"
+                    atype = "c1"  # SP carbon
                 else:
-                    hyb_str = ""
+                    atype = "c3"  # Default
+            elif element == "N":
+                if is_aromatic:
+                    atype = "na"  # Aromatic nitrogen
+                elif hyb == Chem.rdchem.HybridizationType.SP3:
+                    atype = "n3"  # SP3 nitrogen
+                elif hyb == Chem.rdchem.HybridizationType.SP2:
+                    atype = "n2"  # SP2 nitrogen
+                elif hyb == Chem.rdchem.HybridizationType.SP:
+                    atype = "n1"  # SP nitrogen
+                else:
+                    atype = "n3"  # Default
+            elif element == "O":
+                if hyb == Chem.rdchem.HybridizationType.SP3:
+                    atype = "oh"  # Hydroxyl oxygen
+                elif hyb == Chem.rdchem.HybridizationType.SP2:
+                    atype = "o"  # Carbonyl oxygen
+                else:
+                    atype = "o"  # Default
+            elif element == "F":
+                atype = "f"  # Fluorine
+            elif element == "H":
+                # Check what the hydrogen is bonded to
+                neighbors = [n.GetSymbol() for n in atom.GetNeighbors()]
+                if "C" in neighbors:
+                    atype = "hc"  # H attached to C
+                elif "N" in neighbors:
+                    atype = "hn"  # H attached to N
+                elif "O" in neighbors:
+                    atype = "ho"  # H attached to O
+                else:
+                    atype = "h1"  # Default hydrogen
+            else:
+                # For other elements, use lowercase symbol as type
+                atype = element.lower()
 
-                atom_types[i] = f"{element}{hyb_str}"
+            atom_types[i] = atype
 
         return atom_types
 
@@ -246,7 +196,6 @@ class ForceFieldMapper:
                 r_eq = ((pos_i.x - pos_j.x) ** 2 + (pos_i.y - pos_j.y) ** 2 + (pos_i.z - pos_j.z) ** 2) ** 0.5
             else:
                 # Estimate based on atom types and bond type
-                # This would be much more sophisticated in a real implementation
                 atom_i = mol.GetAtomWithIdx(i)
                 atom_j = mol.GetAtomWithIdx(j)
 
@@ -324,7 +273,6 @@ class ForceFieldMapper:
                         type_k = atom_types[k]
 
                         # Default force constant based on atom types
-                        # This would be more sophisticated in a real implementation
                         ktheta = 50.0  # kcal/mol/rad^2
 
                         # Get equilibrium angle from conformer if available
@@ -540,7 +488,7 @@ class ForceFieldMapper:
         logger.debug(f"generate_force_field_parameters: charge_map created: {charge_map}")
 
         # Assign atom types
-        atom_types = self.assign_atom_types(mol, self.force_field_type)
+        atom_types = self.assign_atom_types(mol)
 
         # Predict bond parameters
         bond_params = self.predict_bond_parameters(mol, atom_types)
@@ -555,11 +503,10 @@ class ForceFieldMapper:
         parameters = {
             "mol_name": mol.GetProp("_Name") if mol.HasProp("_Name") else "MOL",
             "atom_types": atom_types,
-            "partial_charges": charge_map,  # This is the charge map Dict[int, float]
+            "partial_charges": charge_map,
             "bonds": bond_params,
             "angles": angle_params,
             "dihedrals": dihedral_params,
-            "force_field_type": self.force_field_type,
         }
         logger.debug(
             f"generate_force_field_parameters: Returning parameters dict with keys: {list(parameters.keys())}, type: {type(parameters)}"
@@ -590,7 +537,7 @@ class ForceFieldMapper:
             "charge_balance_ok": True,
             "bonds_ok": True,
             "angles_ok": True,
-            "dihedrals_ok": True,  # Initialize all as True
+            "dihedrals_ok": True,
         }
 
         # 1. Check charge balance
@@ -628,7 +575,7 @@ class ForceFieldMapper:
                     diff = abs(actual_length - predicted_length)
                     if diff > self.validation_cutoffs["bond_length_deviation"]:
                         validation["passed"] = False
-                        validation["bonds_ok"] = False  # Set specific flag
+                        validation["bonds_ok"] = False
                         validation["issues"].append(
                             {
                                 "type": "bond_length",
@@ -637,20 +584,7 @@ class ForceFieldMapper:
                             }
                         )
 
-        # Placeholder for angle and dihedral checks - to be re-added if they were there
-        # For now, assume they might have been removed or simplified in the version I'm seeing.
-        # If the tests expect 'angles_ok' and 'dihedrals_ok', they will fail if these checks aren't here.
-        # The previous error log showed the test expecting these keys.
-        # The current file content (from error) ends validate_parameters after bond checks.
-        # This means the version of the file used by pytest is different or was reverted.
-
-        # Based on the test failures (KeyError for angles_ok, dihedrals_ok),
-        # the tests *expect* these checks. The file content I have from the error
-        # shows validate_parameters ending prematurely.
-        # I will add simplified checks for angles and dihedrals to set these flags,
-        # assuming the detailed logic was lost/reverted.
-
-        # 3. Check angle parameters (simplified)
+        # 3. Check angle parameters
         if "angles" in parameters:
             for angle_key, angle_param in parameters["angles"].items():
                 if not (0 < angle_param.get("theta_eq", 109.5) < 180.0):  # Basic sanity check
@@ -663,12 +597,12 @@ class ForceFieldMapper:
                             "message": f"Angle {angle_key} has unrealistic theta_eq: {angle_param.get('theta_eq', 'N/A'):.2f}°",
                         }
                     )
-                    break  # Stop at first bad angle for simplicity in this recovery step
+                    break
         else:
-            validation["angles_ok"] = False  # No angles params means not ok if expected
+            validation["angles_ok"] = False
             validation["issues"].append({"type": "missing_angles", "message": "Angle parameters missing."})
 
-        # 4. Check dihedral parameters (simplified)
+        # 4. Check dihedral parameters
         if "dihedrals" in parameters:
             for dihedral_key, dihedral_terms in parameters["dihedrals"].items():
                 for term_params in dihedral_terms:
@@ -682,20 +616,20 @@ class ForceFieldMapper:
                                 "message": f"Dihedral {dihedral_key} term has very high k: {term_params.get('k', 0.0):.2f} kcal/mol",
                             }
                         )
-                        break  # Stop at first bad dihedral term
+                        break
                 if not validation["dihedrals_ok"]:
-                    break  # Stop if already failed
+                    break
         else:
-            validation["dihedrals_ok"] = False  # No dihedrals params means not ok if expected
+            validation["dihedrals_ok"] = False
             validation["issues"].append({"type": "missing_dihedrals", "message": "Dihedral parameters missing."})
 
         return validation
 
-    def export_to_gromacs(
-        self, parameters: Dict[str, Any], mol: Chem.Mol, output_dir: str, base_filename: str  # Added base_filename
+    def export_to_openmm(
+        self, parameters: Dict[str, Any], mol: Chem.Mol, output_dir: str, base_filename: str
     ) -> Tuple[bool, Dict[str, str]]:
         """
-        Export force field parameters to GROMACS format files.
+        Export force field parameters to OpenMM XML format.
 
         Args:
             parameters: Dictionary with force field parameters
@@ -706,449 +640,177 @@ class ForceFieldMapper:
         Returns:
             Tuple of (success, file_paths)
         """
-        if self.simulation_engine != "gromacs":
-            logger.warning(f"Requested export to GROMACS but engine is set to {self.simulation_engine}")
-            logger.info("Proceeding with GROMACS export")
-
         # Create output directory
         os.makedirs(output_dir, exist_ok=True)
 
         # Get molecule name
         mol_name = parameters["mol_name"]
 
-        # File paths
-        top_file = os.path.join(output_dir, f"{mol_name}.top")
-        itp_file = os.path.join(output_dir, f"{mol_name}.itp")
-        gro_file = os.path.join(output_dir, f"{mol_name}.gro")
+        # File path for XML
+        xml_file = os.path.join(output_dir, f"{mol_name}.xml")
 
         try:
-            # Write ITP file (molecule topology)
-            with open(itp_file, "w") as f:
-                # Header
-                f.write(f"; GROMACS itp file for {mol_name}\n")
-                f.write("; Generated by MoML-CA ForceFieldMapper\n")
-                f.write("\n")
+            with open(xml_file, "w") as f:
+                # Write XML header
+                f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+                f.write('<ForceField>\n\n')
 
-                # Atom types
-                f.write("[ atomtypes ]\n")
-                f.write(";name  mass  charge  ptype  sigma  epsilon\n")
-
-                # Write atom types (simplified)
+                # Write AtomTypes section
+                f.write('  <AtomTypes>\n')
+                f.write('    <!-- name = unique string; class = mixing group; element = IUPAC; mass = amu -->\n')
+                
+                # Track written atom types to avoid duplicates
+                written_types = set()
+                
                 for i, atype in parameters["atom_types"].items():
                     atom = mol.GetAtomWithIdx(i)
                     element = atom.GetSymbol()
                     mass = atom.GetMass()
-                    charge = parameters["partial_charges"][i]
+                    
+                    # Skip if already written
+                    if atype in written_types:
+                        continue
+                        
+                    f.write(f'    <Type name="{atype}" class="{atype}" element="{element}" mass="{mass:.6f}"/>\n')
+                    written_types.add(atype)
+                
+                f.write('  </AtomTypes>\n\n')
 
-                    # Simplified LJ parameters
-                    sigma = 0.3  # nm
-                    epsilon = 0.5  # kJ/mol
-
-                    f.write(f"{atype}  {mass:.4f}  {charge:.4f}  A  {sigma:.6f}  {epsilon:.6f}\n")
-
-                f.write("\n")
-
-                # Molecule definition
-                f.write("[ moleculetype ]\n")
-                f.write("; name  nrexcl\n")
-                f.write(f"{mol_name}  3\n\n")
-
-                # Atoms section
-                f.write("[ atoms ]\n")
-                f.write(";nr  type  resnr  resname  atom  cgnr  charge  mass\n")
-
+                # Write Residues section
+                f.write('  <Residues>\n')
+                f.write(f'    <Residue name="{mol_name}">\n')
+                
+                # Write atoms
                 for i in range(mol.GetNumAtoms()):
                     atom = mol.GetAtomWithIdx(i)
                     atype = parameters["atom_types"][i]
                     charge = parameters["partial_charges"][i]
-                    mass = atom.GetMass()
-
-                    # GROMACS uses 1-indexed atom numbers
-                    f.write(
-                        f"{i+1}  {atype}  1  {mol_name}  {atom.GetSymbol()}{i+1}  {i+1}  {charge:.6f}  {mass:.4f}\n"
-                    )
-
-                f.write("\n")
-
-                # Bonds section
-                f.write("[ bonds ]\n")
-                f.write(";ai  aj  funct  c0  c1\n")
-
-                # Keep track of written bonds to avoid duplicates
-                written_bonds = set()
-
+                    f.write(f'      <Atom name="{atom.GetSymbol()}{i+1}" type="{atype}" charge="{charge:.6f}"/>\n')
+                
+                # Write bonds
                 for bond in mol.GetBonds():
                     i = bond.GetBeginAtomIdx()
                     j = bond.GetEndAtomIdx()
+                    atom_i = mol.GetAtomWithIdx(i)
+                    atom_j = mol.GetAtomWithIdx(j)
+                    f.write(f'      <Bond atomName1="{atom_i.GetSymbol()}{i+1}" atomName2="{atom_j.GetSymbol()}{j+1}"/>\n')
+                
+                f.write('    </Residue>\n')
+                f.write('  </Residues>\n\n')
 
-                    # Skip if already written
-                    if (i, j) in written_bonds or (j, i) in written_bonds:
-                        continue
-
-                    # Get parameters
-                    if (i, j) in parameters["bonds"]:
-                        bond_param = parameters["bonds"][(i, j)]
-                        r_eq = bond_param["r_eq"]  # nm
-                        k = bond_param["k"] * 2.0  # Convert to GROMACS units (kJ/mol/nm^2)
-
-                        # GROMACS uses 1-indexed atom numbers
-                        f.write(f"{i+1}  {j+1}  1  {r_eq/10:.6f}  {k*418.4:.1f}\n")
-
-                        # Mark as written
-                        written_bonds.add((i, j))
-
-                f.write("\n")
-
-                # Angles section
-                f.write("[ angles ]\n")
-                f.write(";ai  aj  ak  funct  c0  c1\n")
-
-                # Keep track of written angles to avoid duplicates
-                written_angles = set()
-
-                for angle_idxs, angle_param in parameters["angles"].items():
-                    i, j, k = angle_idxs
-
-                    # Skip if already written
-                    if (i, j, k) in written_angles or (k, j, i) in written_angles:
-                        continue
-
-                    theta_eq = angle_param["theta_eq"]  # degrees
-                    ktheta = angle_param["k"] * 2.0  # Convert to GROMACS units (kJ/mol/rad^2)
-
-                    # GROMACS uses 1-indexed atom numbers
-                    f.write(f"{i+1}  {j+1}  {k+1}  1  {theta_eq:.2f}  {ktheta:.1f}\n")
-
-                    # Mark as written
-                    written_angles.add((i, j, k))
-
-                f.write("\n")
-
-                # Dihedrals section
-                f.write("[ dihedrals ]\n")
-                f.write(";ai  aj  ak  al  funct  c0  c1  c2\n")
-
-                # Keep track of written dihedrals to avoid duplicates
-                written_dihedrals = set()
-
-                for dihedral_idxs, dihedral_params in parameters["dihedrals"].items():
-                    i, j, k, l = dihedral_idxs
-
-                    # Skip if already written
-                    if (i, j, k, l) in written_dihedrals or (l, k, j, i) in written_dihedrals:
-                        continue
-
-                    # Process each term in the dihedral
-                    for idx, term in enumerate(dihedral_params):
-                        if term["type"] == "proper":
-                            # Convert to GROMACS units
-                            k = term["k"] * 4.184  # kcal/mol -> kJ/mol
-                            phase = term["phase"]  # degrees
-                            n = term["n"]
-
-                            # GROMACS periodicity is opposite sign
-                            if phase == 180.0:
-                                k = -k
-
-                            # GROMACS uses 1-indexed atom numbers
-                            f.write(f"{i+1}  {j+1}  {k+1}  {l+1}  9  {phase:.1f}  {k:.2f}  {n}\n")
-
-                    # Mark as written
-                    written_dihedrals.add((i, j, k, l))
-
-                f.write("\n")
-
-                # Pairs section (simplified 1-4 interactions)
-                f.write("[ pairs ]\n")
-                f.write(";ai  aj  funct  c0  c1\n")
-                f.write("; 1-4 interactions generated automatically by GROMACS\n\n")
-
-            # Write TOP file (system topology)
-            with open(top_file, "w") as f:
-                f.write(f"; GROMACS topology for {mol_name}\n")
-                f.write("; Generated by MoML-CA ForceFieldMapper\n\n")
-
-                # Force field definition
-                f.write("; Include force field parameters\n")
-                f.write("; Note: In a full implementation, you would include standard force field files\n")
-                if self.force_field_type == "amber" or self.force_field_type == "gaff":
-                    f.write(';#include "amber99sb.ff/forcefield.itp"\n')
-                else:
-                    f.write(';#include "gromos54a7.ff/forcefield.itp"\n')
-                f.write("\n")
-
-                # Include molecule parameters
-                f.write("; Include molecule parameters\n")
-                f.write(f'#include "{os.path.basename(itp_file)}"\n\n')
-
-                # System definition
-                f.write("[ system ]\n")
-                f.write(f"{mol_name}\n\n")
-
-                # Molecules section
-                f.write("[ molecules ]\n")
-                f.write("; Compound  #mols\n")
-                f.write(f"{mol_name}  1\n")
-
-            # Write GRO file (structure)
-            with open(gro_file, "w") as f:
-                f.write(f"{mol_name} generated by MoML-CA\n")
-                f.write(f"{mol.GetNumAtoms()}\n")
-
-                # Verify 3D coordinates exist
-                if mol.GetNumConformers() == 0:
-                    # Generate 3D coordinates
-                    mol = Chem.AddHs(mol)
-                    AllChem.EmbedMolecule(mol)
-                    AllChem.UFFOptimizeMolecule(mol)
-
-                # Write atom coordinates
-                conf = mol.GetConformer()
-                for i in range(mol.GetNumAtoms()):
-                    atom = mol.GetAtomWithIdx(i)
-                    pos = conf.GetAtomPosition(i)
-
-                    # Convert to nm
-                    x = pos.x / 10.0
-                    y = pos.y / 10.0
-                    z = pos.z / 10.0
-
-                    # GRO format:
-                    # residue_number (5 positions, integer)
-                    # residue_name (5 characters)
-                    # atom name (5 characters)
-                    # atom_number (5 positions, integer)
-                    # position (in nm, x y z in 3 columns, each 8 positions with 3 decimal places)
-                    # velocity (in nm/ps, x y z in 3 columns, each 8 positions with 4 decimal places)
-
-                    # Construct fields for GRO format
-                    res_number = 1
-                    res_name = mol_name[:5]  # Ensure resname is at most 5 chars
-                    atom_name_str = (atom.GetSymbol() + str(i + 1))[:5]  # Ensure atom name is at most 5 chars
-                    atom_num = i + 1
-
-                    f.write(
-                        f"{res_number:5d}{res_name:<5.5s}{atom_name_str:<5.5s}{atom_num:5d}{x:8.3f}{y:8.3f}{z:8.3f}\n"
-                    )
-
-                # Write box dimensions (10x10x10 nm)
-                f.write("  10.00000  10.00000  10.00000\n")
-
-            return True, {"top": top_file, "itp": itp_file, "gro": gro_file}
-
-        except Exception as e:
-            logger.error(f"Error exporting to GROMACS: {str(e)}")
-            return False, {}
-
-    def export_to_amber(
-        self, parameters: Dict[str, Any], mol: Chem.Mol, output_dir: str, base_filename: str  # Added base_filename
-    ) -> Tuple[bool, Dict[str, str]]:
-        """
-        Export force field parameters to AMBER format files.
-
-        Args:
-            parameters: Dictionary with force field parameters
-            mol: RDKit molecule
-            output_dir: Directory to save output files
-            base_filename: Base name for output files
-
-        Returns:
-            Tuple of (success, file_paths)
-        """
-        if self.simulation_engine != "amber":
-            logger.warning(f"Requested export to AMBER but engine is set to {self.simulation_engine}")
-            logger.info("Proceeding with AMBER export")
-
-        # Create output directory
-        os.makedirs(output_dir, exist_ok=True)
-
-        # Get molecule name
-        mol_name = parameters["mol_name"]
-
-        # File paths
-        prmtop_file = os.path.join(output_dir, f"{mol_name}.prmtop")
-        inpcrd_file = os.path.join(output_dir, f"{mol_name}.inpcrd")
-        frcmod_file = os.path.join(output_dir, f"{mol_name}.frcmod")
-        mol2_file = os.path.join(output_dir, f"{mol_name}.mol2")  # Define mol2 file path
-
-        try:
-            # Write FRCMOD file (force field modification file)
-            with open(frcmod_file, "w") as f:
-                f.write(f"FRCMOD file for {mol_name} generated by MoML-CA\n")
-
-                # Bond parameters
-                f.write("BOND\n")
-
-                # Keep track of written bonds to avoid duplicates
+                # Write HarmonicBondForce section
+                f.write('  <HarmonicBondForce>\n')
+                f.write('    <!-- Harmonic bonds: length in nm, k in kJ mol-1 nm-2 -->\n')
+                
+                # Track written bonds to avoid duplicates
                 written_bonds = set()
-
+                
                 for bond_idxs, bond_param in parameters["bonds"].items():
                     i, j = bond_idxs
                     type_i = bond_param["type_i"]
                     type_j = bond_param["type_j"]
-
+                    
                     # Skip if already written
                     bond_key = tuple(sorted([type_i, type_j]))
                     if bond_key in written_bonds:
                         continue
-
-                    r_eq = bond_param["r_eq"]  # Angstroms
-                    k = bond_param["k"]  # kcal/mol/A^2
-
-                    f.write(f"{type_i}-{type_j}  {k:.1f}  {r_eq:.4f}\n")
-
-                    # Mark as written
+                    
+                    r_eq = bond_param["r_eq"] / 10.0  # Convert to nm
+                    k = bond_param["k"] * 2.0 * 418.4  # Convert to kJ/mol/nm^2
+                    
+                    f.write(f'    <Bond class1="{type_i}" class2="{type_j}" length="{r_eq:.6f}" k="{k:.1f}"/>\n')
                     written_bonds.add(bond_key)
+                
+                f.write('  </HarmonicBondForce>\n\n')
 
-                # Angle parameters
-                f.write("\nANGLE\n")
-
-                # Keep track of written angles to avoid duplicates
+                # Write HarmonicAngleForce section
+                f.write('  <HarmonicAngleForce>\n')
+                f.write('    <!-- Harmonic angles: angle in rad, k in kJ mol-1 rad-2 -->\n')
+                
+                # Track written angles to avoid duplicates
                 written_angles = set()
-
+                
                 for angle_idxs, angle_param in parameters["angles"].items():
                     i, j, k = angle_idxs
                     type_i = angle_param["type_i"]
                     type_j = angle_param["type_j"]
                     type_k = angle_param["type_k"]
-
+                    
                     # Skip if already written
-                    if i > k:
-                        angle_key = (type_k, type_j, type_i)
-                    else:
-                        angle_key = (type_i, type_j, type_k)
-
+                    angle_key = tuple(sorted([type_i, type_j, type_k]))
                     if angle_key in written_angles:
                         continue
-
-                    theta_eq = angle_param["theta_eq"]  # degrees
-                    ktheta = angle_param["k"]  # kcal/mol/rad^2
-
-                    f.write(f"{type_i}-{type_j}-{type_k}  {ktheta:.1f}  {theta_eq:.1f}\n")
-
-                    # Mark as written
+                    
+                    theta_eq = angle_param["theta_eq"] * np.pi / 180.0  # Convert to radians
+                    ktheta = angle_param["k"] * 2.0 * 4.184  # Convert to kJ/mol/rad^2
+                    
+                    f.write(f'    <Angle class1="{type_i}" class2="{type_j}" class3="{type_k}" angle="{theta_eq:.6f}" k="{ktheta:.1f}"/>\n')
                     written_angles.add(angle_key)
+                
+                f.write('  </HarmonicAngleForce>\n\n')
 
-                # Dihedral parameters
-                f.write("\nDIHEDRAL\n")
-
-                # Keep track of written dihedrals to avoid duplicates
+                # Write PeriodicTorsionForce section
+                f.write('  <PeriodicTorsionForce>\n')
+                f.write('    <!-- Proper torsions: Fourier series -->\n')
+                
+                # Track written dihedrals to avoid duplicates
                 written_dihedrals = set()
-
+                
                 for dihedral_idxs, dihedral_params in parameters["dihedrals"].items():
                     i, j, k, l = dihedral_idxs
-
-                    # Get atom types
                     type_i = parameters["atom_types"][i]
                     type_j = parameters["atom_types"][j]
                     type_k = parameters["atom_types"][k]
                     type_l = parameters["atom_types"][l]
-
+                    
                     # Skip if already written
-                    if i > l:
-                        dihedral_key = (type_l, type_k, type_j, type_i)
-                    else:
-                        dihedral_key = (type_i, type_j, type_k, type_l)
-
+                    dihedral_key = tuple(sorted([type_i, type_j, type_k, type_l]))
                     if dihedral_key in written_dihedrals:
                         continue
-
-                    # Write each term
+                    
+                    # Write each term in the dihedral
+                    terms = []
                     for term in dihedral_params:
                         if term["type"] == "proper":
-                            k = term["k"]  # kcal/mol
-                            phase = term["phase"]  # degrees
-                            n = term["n"]  # periodicity
-
-                            f.write(f"{type_i}-{type_j}-{type_k}-{type_l} 1 {k:.3f} {phase:.1f} {n:.1f}\n")
-
-                    # Mark as written
+                            k = term["k"] * 4.184  # Convert to kJ/mol
+                            phase = term["phase"] * np.pi / 180.0  # Convert to radians
+                            n = term["n"]
+                            terms.append(f'periodicity{n}="{n}" phase{n}="{phase:.6f}" k{n}="{k:.6f}"')
+                    
+                    if terms:
+                        f.write(f'    <Proper type1="{type_i}" type2="{type_j}" type3="{type_k}" type4="{type_l}" {" ".join(terms)}/>\n')
+                    
                     written_dihedrals.add(dihedral_key)
+                
+                f.write('  </PeriodicTorsionForce>\n\n')
 
-                # Improper dihedrals (not implemented in this simplified version)
-                f.write("\nIMPROPER\n")
+                # Write NonbondedForce section
+                f.write('  <NonbondedForce coulomb14scale="0.833333" lj14scale="0.5">\n')
+                f.write('    <UseAttributeFromResidue name="charge"/>\n')
+                
+                # Track written atom types to avoid duplicates
+                written_nb_types = set()
+                
+                for i, atype in parameters["atom_types"].items():
+                    if atype in written_nb_types:
+                        continue
+                    
+                    # Simplified LJ parameters
+                    sigma = 0.3  # nm
+                    epsilon = 0.5  # kJ/mol
+                    
+                    f.write(f'    <Atom type="{atype}" sigma="{sigma:.6f}" epsilon="{epsilon:.6f}"/>\n')
+                    written_nb_types.add(atype)
+                
+                f.write('  </NonbondedForce>\n\n')
 
-                # Nonbonded parameters
-                f.write("\nNONBON\n")
+                # Close ForceField tag
+                f.write('</ForceField>\n')
 
-            # In a real implementation, we would call AmberTools (tleap) to generate prmtop/inpcrd
-            # For this simplified example, we'll create placeholder files
-
-            with open(prmtop_file, "w") as f:
-                f.write("This is a placeholder for a real AMBER prmtop file.\n")
-                f.write("In a real implementation, this would be generated using AmberTools (tleap).\n")
-
-            with open(inpcrd_file, "w") as f:
-                f.write("This is a placeholder for a real AMBER inpcrd file.\n")
-                f.write("In a real implementation, this would be generated using AmberTools (tleap).\n")
-
-            with open(mol2_file, "w") as f:  # Create placeholder mol2 file
-                f.write(f"@<TRIPOS>MOLECULE\n{mol_name}\n")
-                f.write(f"{mol.GetNumAtoms()} {mol.GetNumBonds()} 0 0 0\n")  # Atom count, bond count
-                f.write("SMALL\nGASTEIGER\n\n@<TRIPOS>ATOM\n")
-                # Minimal atom info for placeholder
-                for i in range(mol.GetNumAtoms()):
-                    atom = mol.GetAtomWithIdx(i)
-                    charge = parameters.get("partial_charges", {}).get(i, 0.0)
-                    f.write(
-                        f"{i+1:>4} {atom.GetSymbol():<4} 0.0000 0.0000 0.0000 {atom.GetSymbol().upper():<4} 1 {mol_name} {charge:.4f}\n"
-                    )
-                f.write("@<TRIPOS>BOND\n")
-                for bond_idx, bond in enumerate(mol.GetBonds()):
-                    f.write(
-                        f"{bond_idx+1:>5} {bond.GetBeginAtomIdx()+1:>5} {bond.GetEndAtomIdx()+1:>5} {bond.GetBondTypeAsDouble():.1f}\n"
-                    )
-
-            return True, {
-                "prmtop": prmtop_file,
-                "inpcrd": inpcrd_file,
-                "frcmod": frcmod_file,
-                "mol2": mol2_file,  # Add mol2 to returned dict
-            }
+            return True, {"xml": xml_file}
 
         except Exception as e:
-            logger.error(f"Error exporting to AMBER: {str(e)}")
-            return False, {}
-
-    def export_parameters(
-        self,
-        parameters: Dict[str, Any],
-        mol: Chem.Mol,
-        output_dir: str,
-        base_filename: str,  # Added base_filename
-        engine: Optional[str] = None,
-    ) -> Tuple[bool, Dict[str, str]]:
-        """
-        Export force field parameters to files.
-
-        Args:
-            parameters: Dictionary with force field parameters
-            mol: RDKit molecule
-            output_dir: Directory to save output files
-            base_filename: Base name for output files
-            engine: Optional simulation engine to export to
-
-        Returns:
-            Tuple of (success, file_paths)
-        """
-        # Use instance engine if not specified
-        if engine is None:
-            engine = self.simulation_engine
-
-        # Export based on selected engine
-        if engine == "gromacs":
-            # Assuming a default base_filename if not provided, or it should be passed down
-            base_fn = parameters.get("mol_name", "molecule")
-            return self.export_to_gromacs(parameters, mol, output_dir, base_filename=base_fn)
-        elif engine == "amber":
-            base_fn = parameters.get("mol_name", "molecule")
-            return self.export_to_amber(parameters, mol, output_dir, base_filename=base_fn)
-        elif engine == "openmm":
-            # Not implemented in this simplified version
-            logger.error("OpenMM export not implemented in this version")
-            return False, {}
-        else:
-            logger.error(f"Unsupported simulation engine: {engine}")
+            logger.error(f"Error exporting to OpenMM: {str(e)}")
             return False, {}
 
     def convert_mgnn_predictions_to_force_field(
@@ -1156,8 +818,7 @@ class ForceFieldMapper:
         mol: Chem.Mol,
         node_predictions: Union[Dict, List[float]],
         output_dir: str,
-        base_filename: str,  # Added base_filename
-        engine: Optional[str] = None,
+        base_filename: str,
     ) -> Tuple[bool, Dict[str, Any]]:
         """
         Convert MGNN model predictions to force field files.
@@ -1169,7 +830,6 @@ class ForceFieldMapper:
             node_predictions: Node-level predictions from MGNN model (partial charges)
             output_dir: Directory to save output files
             base_filename: Base name for output files
-            engine: Optional simulation engine to export to
 
         Returns:
             Tuple of (success, results)
@@ -1197,7 +857,7 @@ class ForceFieldMapper:
         validation = self.validate_parameters(parameters, mol)
 
         # Export parameters to files
-        success, file_paths = self.export_parameters(parameters, mol, output_dir, base_filename, engine)
+        success, file_paths = self.export_to_openmm(parameters, mol, output_dir, base_filename)
 
         if not success:
             logger.error("Failed to export force field parameters")
@@ -1209,18 +869,14 @@ class ForceFieldMapper:
         return True, results
 
 
-def create_force_field_mapper(
-    force_field_type: str = "amber", simulation_engine: str = "gromacs", config: Optional[Dict[str, Any]] = None
-) -> ForceFieldMapper:
+def create_force_field_mapper(config: Optional[Dict[str, Any]] = None) -> ForceFieldMapper:
     """
     Create a ForceFieldMapper instance.
 
     Args:
-        force_field_type: Type of force field to generate
-        simulation_engine: Target simulation engine
         config: Additional configuration parameters
 
     Returns:
         ForceFieldMapper instance
     """
-    return ForceFieldMapper(force_field_type, simulation_engine, config)
+    return ForceFieldMapper(config)

--- a/tests/test_force_field_mapper.py
+++ b/tests/test_force_field_mapper.py
@@ -10,7 +10,7 @@ import tempfile
 import shutil
 from rdkit import Chem
 from rdkit.Chem import AllChem
-import torch  # Added for MGNN prediction mocking
+import torch
 
 from moml.simulation.molecular_dynamics.force_field_mapper import ForceFieldMapper
 
@@ -67,28 +67,13 @@ class TestForceFieldMapper:
     def test_init_default(self):
         """Test ForceFieldMapper initialization with default parameters."""
         mapper = ForceFieldMapper()
-        assert mapper.force_field_type == "amber"  # Default
-        assert mapper.simulation_engine == "gromacs"  # Default
+        assert mapper.config == {}
 
     def test_init_custom(self):
-        """Test ForceFieldMapper initialization with custom parameters."""
-        mapper = ForceFieldMapper(force_field_type="gaff", simulation_engine="openmm")
-        assert mapper.force_field_type == "gaff"
-        assert mapper.simulation_engine == "openmm"
-
-    def test_init_invalid_ff_engine(self, caplog):
-        """Test initialization with invalid force field type and engine, checking defaults and warnings."""
-        with caplog.at_level(logging.INFO):  # Capture INFO level logs
-            ForceFieldMapper(force_field_type="invalid_ff", simulation_engine="invalid_engine")
-        assert "Force field type 'invalid_ff' not in supported formats" in caplog.text
-        assert "Defaulting to 'amber' force field type." in caplog.text
-        assert "Simulation engine 'invalid_engine' not in supported engines" in caplog.text
-        assert "Defaulting to 'gromacs' simulation engine." in caplog.text  # Added "simulation engine."
-
-        # Check that defaults were applied
-        mapper = ForceFieldMapper(force_field_type="invalid_ff", simulation_engine="invalid_engine")
-        assert mapper.force_field_type == "amber"
-        assert mapper.simulation_engine == "gromacs"
+        """Test ForceFieldMapper initialization with custom config."""
+        config = {"test_param": "test_value"}
+        mapper = ForceFieldMapper(config=config)
+        assert mapper.config == config
 
     def test_map_partial_charges_no_normalize(self, ethanol_mol_3d: Chem.Mol):
         """Test map_partial_charges without normalization."""
@@ -121,14 +106,11 @@ class TestForceFieldMapper:
         with pytest.raises(ValueError, match="doesn't match number of charges"):
             mapper.map_partial_charges(ethanol_mol_3d, charges_in)
 
-    def test_assign_atom_types_gaff_ethanol(self, ethanol_mol_3d: Chem.Mol):
-        """Test assign_atom_types for ethanol with GAFF-like typing."""
-        mapper = ForceFieldMapper(force_field_type="gaff")
+    def test_assign_atom_types_ethanol(self, ethanol_mol_3d: Chem.Mol):
+        """Test assign_atom_types for ethanol."""
+        mapper = ForceFieldMapper()
         atom_types = mapper.assign_atom_types(ethanol_mol_3d)
         # CCOH: C(H3)-C(H2)-O-H
-        # Expected (simplified GAFF): c3, c3, oh, ho, hc, hc, hc, hc, hc
-        # Order depends on RDKit atom indexing after AddHs
-        # This test is sensitive to the exact simplified logic in assign_atom_types
         assert len(atom_types) == ethanol_mol_3d.GetNumAtoms()
         # Example check for one atom (e.g. Oxygen)
         oxygen_idx = -1
@@ -140,8 +122,8 @@ class TestForceFieldMapper:
         assert atom_types[oxygen_idx] == "oh"  # Hydroxyl oxygen
 
     def test_assign_atom_types_pfoa_frag(self, pfoa_frag_mol_3d: Chem.Mol):
-        """Test assign_atom_types for PFOA fragment with GAFF-like typing."""
-        mapper = ForceFieldMapper(force_field_type="gaff")
+        """Test assign_atom_types for PFOA fragment."""
+        mapper = ForceFieldMapper()
         atom_types = mapper.assign_atom_types(pfoa_frag_mol_3d)
         # CF3COOH
         # Check a fluorine and the carbonyl carbon
@@ -225,8 +207,6 @@ class TestForceFieldMapper:
         assert "theta_eq" in param_set and isinstance(param_set["theta_eq"], float)
         assert 0 < param_set["theta_eq"] < 180  # Sanity check for angle
 
-    # Similar tests for predict_dihedral_parameters can be added
-
     def test_generate_force_field_parameters(self, ethanol_mol_3d: Chem.Mol):
         """Test the main generate_force_field_parameters method."""
         mapper = ForceFieldMapper()
@@ -238,127 +218,41 @@ class TestForceFieldMapper:
         ff_params = mapper.generate_force_field_parameters(ethanol_mol_3d, partial_charges=mgnn_charges_list)
 
         assert "atom_types" in ff_params
-        assert "partial_charges" in ff_params  # Corrected key from 'charges'
+        assert "partial_charges" in ff_params
         assert "bonds" in ff_params
         assert "angles" in ff_params
         assert "dihedrals" in ff_params
-        assert len(ff_params["partial_charges"]) == num_atoms  # Corrected key from 'charges'
+        assert len(ff_params["partial_charges"]) == num_atoms
         assert len(ff_params["bonds"]) > 0
         assert len(ff_params["angles"]) > 0
-        # Dihedrals might be empty for very small molecules if logic is strict
 
-    @pytest.mark.skip(
-        reason="Test expects list-based convert_mgnn_predictions_to_force_field, but current impl is single-molecule."
-    )
-    def test_convert_mgnn_predictions_to_force_field(self, ethanol_mol_3d: Chem.Mol):
-        """Test the main conversion entry point."""
+    def test_export_to_openmm(self, ethanol_mol_3d: Chem.Mol, temp_output_dir: str):
+        """Test OpenMM XML export functionality."""
         mapper = ForceFieldMapper()
-        num_atoms = ethanol_mol_3d.GetNumAtoms()
-        # Example MGNN output structure (assuming node_pred are charges)
-        mgnn_predictions = {
-            "node_pred": torch.tensor([[0.01 * i] for i in range(num_atoms)], dtype=torch.float)
-            # Potentially other keys like 'bond_pred', 'angle_pred' if model predicts them
-        }
-
-        # The method expects a list of RDKit molecules and list of predictions
-        ff_params_list = mapper.convert_mgnn_predictions_to_force_field(
-            mol_list=[ethanol_mol_3d], preds_list=[mgnn_predictions]
-        )
-        assert len(ff_params_list) == 1
-        ff_params = ff_params_list[0]
-
-        assert "atom_types" in ff_params
-        assert "partial_charges" in ff_params  # Corrected key
-        assert len(ff_params["partial_charges"]) == num_atoms  # Corrected key
-        # Check if charges from mgnn_predictions were used (after potential normalization)
-        # This requires knowing the exact mapping logic within convert_mgnn_predictions_to_force_field
-        # For now, just check structure.
-
-    def test_export_to_gromacs(self, ethanol_mol_3d: Chem.Mol, temp_output_dir: str):
-        """Test GROMACS export functionality."""
-        mapper = ForceFieldMapper(simulation_engine="gromacs")
         num_atoms = ethanol_mol_3d.GetNumAtoms()
         charges_for_ff_params = [0.0 for _ in range(num_atoms)]  # Neutral for simplicity
         ff_params = mapper.generate_force_field_parameters(ethanol_mol_3d, partial_charges=charges_for_ff_params)
 
         base_filename = "ethanol_test"
-        output_paths = mapper.export_to_gromacs(  # Corrected argument order and names
+        success, output_paths = mapper.export_to_openmm(
             parameters=ff_params, mol=ethanol_mol_3d, output_dir=temp_output_dir, base_filename=base_filename
         )
 
-        assert (
-            isinstance(output_paths, tuple) and len(output_paths) == 2
-        ), "export_to_gromacs should return a tuple (bool, dict)"
-        assert output_paths[0] is True, "export_to_gromacs success flag should be True"
-        returned_files_dict = output_paths[1]
+        assert success is True, "export_to_openmm success flag should be True"
+        assert "xml" in output_paths
+        assert os.path.exists(output_paths["xml"])
 
-        assert "itp" in returned_files_dict
-        assert "top" in returned_files_dict
-        assert "gro" in returned_files_dict
-        assert os.path.exists(returned_files_dict["itp"])
-        assert os.path.exists(returned_files_dict["top"])
-        assert os.path.exists(returned_files_dict["gro"])
-
-        # Basic content check for ITP
-        with open(returned_files_dict["itp"], "r") as f:
+        # Basic content check for XML
+        with open(output_paths["xml"], "r") as f:
             content = f.read()
-            assert "[ moleculetype ]" in content
-            assert "[ atoms ]" in content
-            assert "[ bonds ]" in content
-            assert "[ angles ]" in content  # Typically present
-            assert "[ dihedrals ]" in content  # Typically present
-            # Add more checks as needed
-
-    def test_export_to_amber(self, ethanol_mol_3d: Chem.Mol, temp_output_dir: str):
-        """Test AMBER export functionality (frcmod and mol2)."""
-        mapper = ForceFieldMapper(simulation_engine="amber")
-        num_atoms = ethanol_mol_3d.GetNumAtoms()
-        # Use simple charges that sum to zero for ethanol
-        mgnn_preds = {"partial_charges": [0.1, -0.2, 0.1] + [0.0] * (num_atoms - 3)}  # Dummy, ensure length matches
-        if len(mgnn_preds["partial_charges"]) < num_atoms:
-            mgnn_preds["partial_charges"].extend([0.0] * (num_atoms - len(mgnn_preds["partial_charges"])))
-        else:
-            mgnn_preds["partial_charges"] = mgnn_preds["partial_charges"][:num_atoms]
-
-        # Normalize to ensure sum is close to zero for a neutral molecule
-        current_sum = sum(mgnn_preds["partial_charges"])
-        correction = -current_sum / num_atoms
-        charges_for_ff_params = [q + correction for q in mgnn_preds["partial_charges"]]
-
-        ff_params = mapper.generate_force_field_parameters(ethanol_mol_3d, partial_charges=charges_for_ff_params)
-
-        base_filename = "ethanol_amber_test"
-        output_paths = mapper.export_to_amber(  # Corrected argument order and names
-            parameters=ff_params, mol=ethanol_mol_3d, output_dir=temp_output_dir, base_filename=base_filename
-        )
-
-        assert (
-            isinstance(output_paths, tuple) and len(output_paths) == 2
-        ), "export_to_amber should return a tuple (bool, dict)"
-        assert output_paths[0] is True, "export_to_amber success flag should be True"
-        returned_files = output_paths[1]
-        assert "frcmod" in returned_files
-        assert "mol2" in returned_files
-        assert os.path.exists(returned_files["frcmod"])
-        assert os.path.exists(returned_files["mol2"])
-
-        # Basic content check for FRCMOD
-        with open(returned_files["frcmod"], "r") as f:
-            content = f.read()
-            # "MASS" section is not currently written by the simplified export_to_amber
-            assert "BOND" in content
-            assert "ANGLE" in content
-            assert "DIHE" in content  # Proper dihedrals
-            assert "NONB" in content
-
-        # Basic content check for MOL2
-        with open(returned_files["mol2"], "r") as f:
-            content = f.read()
-            assert "@<TRIPOS>MOLECULE" in content
-            assert "@<TRIPOS>ATOM" in content
-            assert f"{ethanol_mol_3d.GetNumAtoms()} " in content  # Check atom count
-            assert "@<TRIPOS>BOND" in content
-            assert f"{ethanol_mol_3d.GetNumBonds()} " in content  # Check bond count
+            assert '<?xml version="1.0" encoding="UTF-8"?>' in content
+            assert "<ForceField>" in content
+            assert "<AtomTypes>" in content
+            assert "<Residues>" in content
+            assert "<HarmonicBondForce>" in content
+            assert "<HarmonicAngleForce>" in content
+            assert "<PeriodicTorsionForce>" in content
+            assert "<NonbondedForce>" in content
 
     def test_validate_parameters_valid(self, ethanol_mol_3d: Chem.Mol):
         """Test validate_parameters with good, default parameters."""
@@ -367,23 +261,19 @@ class TestForceFieldMapper:
         charges_for_ff_params = [0.0] * num_atoms  # Neutral
         ff_params = mapper.generate_force_field_parameters(ethanol_mol_3d, partial_charges=charges_for_ff_params)
 
-        validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)  # Args are correct
+        validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)
 
         assert validation_results["charge_balance_ok"]
         assert validation_results["bonds_ok"]
         assert validation_results["angles_ok"]
-        assert validation_results["dihedrals_ok"]  # Assuming default dihedrals are fine
+        assert validation_results["dihedrals_ok"]
 
     def test_validate_parameters_invalid_charge(self, ethanol_mol_3d: Chem.Mol):
         """Test validate_parameters with imbalanced charges."""
         mapper = ForceFieldMapper()
         num_atoms = ethanol_mol_3d.GetNumAtoms()
-        # Pass the list directly for partial_charges argument
         charges_for_ff_params = [1.0] * num_atoms  # Highly imbalanced
         ff_params = mapper.generate_force_field_parameters(ethanol_mol_3d, partial_charges=charges_for_ff_params)
-        # Manually override charges to ensure they are not normalized away by map_partial_charges
-        # if generate_force_field_parameters internally calls map_partial_charges with normalize=True
-        # The key in ff_params is 'partial_charges'
         ff_params["partial_charges"] = {i: 1.0 for i in range(num_atoms)}
 
         validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)
@@ -401,7 +291,7 @@ class TestForceFieldMapper:
             first_bond_key = list(ff_params["bonds"].keys())[0]
             ff_params["bonds"][first_bond_key]["r_eq"] = 0.01  # Too short
 
-        validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)  # Args are correct
+        validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)
         assert not validation_results["bonds_ok"]
 
     def test_validate_parameters_invalid_angle(self, ethanol_mol_3d: Chem.Mol):
@@ -415,7 +305,7 @@ class TestForceFieldMapper:
             first_angle_key = list(ff_params["angles"].keys())[0]
             ff_params["angles"][first_angle_key]["theta_eq"] = 300.0  # Impossible angle
 
-        validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)  # Args are correct
+        validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)
         assert not validation_results["angles_ok"]
 
     def test_validate_parameters_invalid_dihedral(self, ethanol_mol_3d: Chem.Mol):
@@ -431,89 +321,28 @@ class TestForceFieldMapper:
             if ff_params["dihedrals"][first_dihedral_key]:
                 ff_params["dihedrals"][first_dihedral_key][0]["k"] = 100.0  # kcal/mol, very high
 
-        validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)  # Args are correct
+        validation_results = mapper.validate_parameters(parameters=ff_params, mol=ethanol_mol_3d)
         assert not validation_results["dihedrals_ok"]
 
-    @pytest.mark.skip(
-        reason="Test expects list-based convert_mgnn_predictions_to_force_field, but current impl is single-molecule."
-    )
-    def test_convert_mgnn_predictions_uses_only_charges_currently(self, ethanol_mol_3d: Chem.Mol):
-        """
-        Tests that convert_mgnn_predictions_to_force_field currently primarily uses
-        'node_pred' for charges, and other geometric parameters are derived,
-        reflecting the TODO in generate_force_field_parameters.
-        """
+    def test_convert_mgnn_predictions_to_force_field(self, ethanol_mol_3d: Chem.Mol, temp_output_dir: str):
+        """Test the main conversion entry point."""
         mapper = ForceFieldMapper()
         num_atoms = ethanol_mol_3d.GetNumAtoms()
-
-        # Mock MGNN predictions
-        # Charges that should be used
-        predicted_charges_tensor = torch.tensor([[0.05 * i] for i in range(num_atoms)], dtype=torch.float)
-        # Dummy bond/angle predictions that should NOT be directly used by current implementation
-        dummy_bond_param = 1.23
-        dummy_angle_param = 109.0
-
-        mgnn_predictions_detailed = {
-            "node_pred": predicted_charges_tensor,  # For charges
-            "bond_length_pred": torch.tensor([[dummy_bond_param]] * ethanol_mol_3d.GetNumBonds()),  # Dummy
-            "angle_pred": torch.tensor(
-                [[dummy_angle_param]]
-                * len(mapper.predict_angle_parameters(ethanol_mol_3d, mapper.assign_atom_types(ethanol_mol_3d)))
-            ),  # Dummy
+        # Example MGNN output structure (assuming node_pred are charges)
+        mgnn_predictions = {
+            "node_pred": torch.tensor([[0.01 * i] for i in range(num_atoms)], dtype=torch.float)
         }
 
-        # Generate parameters with detailed (but mostly unused) predictions
-        ff_params_list_detailed = mapper.convert_mgnn_predictions_to_force_field(
-            mol_list=[ethanol_mol_3d], preds_list=[mgnn_predictions_detailed]
+        success, results = mapper.convert_mgnn_predictions_to_force_field(
+            mol=ethanol_mol_3d,
+            node_predictions=mgnn_predictions,
+            output_dir=temp_output_dir,
+            base_filename="ethanol"
         )
-        assert len(ff_params_list_detailed) == 1
-        ff_params_detailed = ff_params_list_detailed[0]
 
-        # Check charges: they should reflect normalized 'node_pred'
-        expected_charges_normalized = mapper.map_partial_charges(
-            ethanol_mol_3d, predicted_charges_tensor.squeeze().tolist()
-        )
-        for i in range(num_atoms):
-            # Assuming ff_params_detailed['partial_charges'] is a dict {atom_idx: charge_val}
-            assert (
-                abs(ff_params_detailed["partial_charges"][i] - expected_charges_normalized[i]) < 1e-5
-            )  # Corrected key
-
-        # Generate parameters using only charge predictions (for comparison)
-        mgnn_predictions_charges_only = {"node_pred": predicted_charges_tensor}
-        ff_params_list_charges_only = mapper.convert_mgnn_predictions_to_force_field(
-            mol_list=[ethanol_mol_3d], preds_list=[mgnn_predictions_charges_only]
-        )
-        ff_params_charges_only = ff_params_list_charges_only[0]
-
-        # Check bonds: Bond parameters should be identical, as they are derived, not from 'bond_length_pred'
-        assert len(ff_params_detailed["bonds"]) == len(ff_params_charges_only["bonds"])
-        for bond_key in ff_params_detailed["bonds"]:
-            assert bond_key in ff_params_charges_only["bonds"]
-            # Check r_eq; it should NOT be dummy_bond_param
-            assert ff_params_detailed["bonds"][bond_key]["r_eq"] != dummy_bond_param
-            assert (
-                abs(ff_params_detailed["bonds"][bond_key]["r_eq"] - ff_params_charges_only["bonds"][bond_key]["r_eq"])
-                < 1e-6
-            )
-            assert (
-                abs(ff_params_detailed["bonds"][bond_key]["k"] - ff_params_charges_only["bonds"][bond_key]["k"]) < 1e-6
-            )
-
-        # Check angles: Angle parameters should be identical
-        assert len(ff_params_detailed["angles"]) == len(ff_params_charges_only["angles"])
-        for angle_key in ff_params_detailed["angles"]:
-            assert angle_key in ff_params_charges_only["angles"]
-            # Check theta_eq; it should NOT be dummy_angle_param
-            assert ff_params_detailed["angles"][angle_key]["theta_eq"] != dummy_angle_param
-            assert (
-                abs(
-                    ff_params_detailed["angles"][angle_key]["theta_eq"]
-                    - ff_params_charges_only["angles"][angle_key]["theta_eq"]
-                )
-                < 1e-6
-            )
-            assert (
-                abs(ff_params_detailed["angles"][angle_key]["k"] - ff_params_charges_only["angles"][angle_key]["k"])
-                < 1e-6
-            )
+        assert success is True
+        assert "parameters" in results
+        assert "validation" in results
+        assert "file_paths" in results
+        assert "xml" in results["file_paths"]
+        assert os.path.exists(results["file_paths"]["xml"])


### PR DESCRIPTION
### **User description**
This pull request introduces significant enhancements to the MGNN models (`DJMGNN` and `HMGNN`) by adding support for environmental vectors (`env_vec`) and improves the `ForceFieldMapper` testing framework by simplifying and updating test cases. Below is a summary of the most important changes:

### Enhancements to MGNN Models:
* **Environmental Vector Support in `DJMGNN`:**
  - Added `env_dim` and `env_mlp` parameters to the `__init__` method, enabling optional environmental vector projection. (`moml/models/mgnn/djmgnn.py`, [[1]](diffhunk://#diff-e48edfc620052e29e29d116e3f50f83291bf10c6486ee88a5a19bc83cd762cc7R211-R215) [[2]](diffhunk://#diff-e48edfc620052e29e29d116e3f50f83291bf10c6486ee88a5a19bc83cd762cc7R242-R260)
  - Updated the `forward` method to incorporate the environmental vector (`env_vec`) into graph and node predictions. (`moml/models/mgnn/djmgnn.py`, [[1]](diffhunk://#diff-e48edfc620052e29e29d116e3f50f83291bf10c6486ee88a5a19bc83cd762cc7L328-R342) [[2]](diffhunk://#diff-e48edfc620052e29e29d116e3f50f83291bf10c6486ee88a5a19bc83cd762cc7L406-R429)

* **Environmental Vector Support in `HMGNN`:**
  - Added `env_dim` and `env_mlp` parameters to the `__init__` method and integrated environmental vector projection into graph predictions. (`moml/models/mgnn/hmgnn.py`, [[1]](diffhunk://#diff-5c84f1a32a4468a14d32a7eb12f2d335e9f18d52e7785b307f1007a7297dd05bR199-R200) [[2]](diffhunk://#diff-5c84f1a32a4468a14d32a7eb12f2d335e9f18d52e7785b307f1007a7297dd05bR239-R247) [[3]](diffhunk://#diff-5c84f1a32a4468a14d32a7eb12f2d335e9f18d52e7785b307f1007a7297dd05bL254-R265)
  - Modified the `forward` method to handle environmental vectors (`env_vec`) for hierarchical graph predictions. (`moml/models/mgnn/hmgnn.py`, [[1]](diffhunk://#diff-5c84f1a32a4468a14d32a7eb12f2d335e9f18d52e7785b307f1007a7297dd05bR289) [[2]](diffhunk://#diff-5c84f1a32a4468a14d32a7eb12f2d335e9f18d52e7785b307f1007a7297dd05bR344-L333)

### Improvements to `ForceFieldMapper` Tests:
* **Simplified Initialization Tests:**
  - Removed legacy tests for invalid configurations and replaced them with a streamlined test for custom configuration. (`tests/test_force_field_mapper.py`, [tests/test_force_field_mapper.pyL70-R76](diffhunk://#diff-986f5d730c20f0038e909201f0487e34fefde0b7596e1321bfbb76d8192c5ff4L70-R76))

* **Updated Test Cases:**
  - Refactored `test_assign_atom_types` to remove dependency on specific force field types like GAFF. (`tests/test_force_field_mapper.py`, [[1]](diffhunk://#diff-986f5d730c20f0038e909201f0487e34fefde0b7596e1321bfbb76d8192c5ff4L124-L131) [[2]](diffhunk://#diff-986f5d730c20f0038e909201f0487e34fefde0b7596e1321bfbb76d8192c5ff4L143-R126)
  - Added a new test for exporting force field parameters to OpenMM XML format. (`tests/test_force_field_mapper.py`, [tests/test_force_field_mapper.pyL241-R255](diffhunk://#diff-986f5d730c20f0038e909201f0487e34fefde0b7596e1321bfbb76d8192c5ff4L241-R255))

* **Removed Redundant and Legacy Tests:**
  - Eliminated outdated tests for exporting to GROMACS and AMBER, focusing on OpenMM export functionality. (`tests/test_force_field_mapper.py`, [tests/test_force_field_mapper.pyL241-R255](diffhunk://#diff-986f5d730c20f0038e909201f0487e34fefde0b7596e1321bfbb76d8192c5ff4L241-R255))

These changes enhance the flexibility of the MGNN models by supporting environmental data and streamline the testing framework for better maintainability and clarity.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add environmental vector support to DJMGNN and HMGNN models.
  - Integrate optional env vector projection and fusion in model heads.
  - Update forward methods to accept and use env_vec.

- Refactor ForceFieldMapper for OpenMM XML export only.
  - Remove support for multiple force field types and engines.
  - Simplify atom typing and export logic for OpenMM.
  - Update parameter validation and export methods.

- Update and simplify ForceFieldMapper tests.
  - Remove tests for deprecated force field/engine options.
  - Add/modify tests for OpenMM XML export and new initialization.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>djmgnn.py</strong><dd><code>Add environmental vector support to DJMGNN model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moml/models/mgnn/djmgnn.py

<li>Add env_dim and env_mlp parameters to DJMGNN.<br> <li> Integrate optional environmental vector projection in __init__ and <br>forward.<br> <li> Update node and graph heads to fuse env vector if provided.<br> <li> Update forward signature and logic to support env_vec.


</details>


  </td>
  <td><a href="https://github.com/SAKETH11111/MoML-CA/pull/5/files#diff-e48edfc620052e29e29d116e3f50f83291bf10c6486ee88a5a19bc83cd762cc7">+28/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hmgnn.py</strong><dd><code>Add environmental vector support to HMGNN model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moml/models/mgnn/hmgnn.py

<li>Add env_dim and env_mlp parameters to HMGNN.<br> <li> Integrate environmental vector projection in __init__ and forward.<br> <li> Update graph heads to fuse env vector if provided.<br> <li> Update forward signature and logic to support env_vec.


</details>


  </td>
  <td><a href="https://github.com/SAKETH11111/MoML-CA/pull/5/files#diff-5c84f1a32a4468a14d32a7eb12f2d335e9f18d52e7785b307f1007a7297dd05b">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>force_field_mapper.py</strong><dd><code>Refactor ForceFieldMapper for OpenMM XML export only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moml/simulation/molecular_dynamics/force_field_mapper.py

<li>Remove support for multiple force field types and engines.<br> <li> Simplify atom typing to element/hybridization only.<br> <li> Refactor export logic to generate OpenMM XML format exclusively.<br> <li> Update parameter validation and export entry points.<br> <li> Remove legacy GROMACS/AMBER export and related logic.


</details>


  </td>
  <td><a href="https://github.com/SAKETH11111/MoML-CA/pull/5/files#diff-13bbd381af7326a828e96455ebc2b61fad0d48b491c286d2cd1a283cf8d1fbee">+186/-530</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_force_field_mapper.py</strong><dd><code>Update ForceFieldMapper tests for OpenMM-only and new API</code></dd></summary>
<hr>

tests/test_force_field_mapper.py

<li>Remove tests for deprecated force field/engine options.<br> <li> Update tests to reflect OpenMM-only export and new initialization.<br> <li> Add/modify tests for OpenMM XML export and conversion entry point.<br> <li> Simplify atom typing and parameter generation tests.


</details>


  </td>
  <td><a href="https://github.com/SAKETH11111/MoML-CA/pull/5/files#diff-986f5d730c20f0038e909201f0487e34fefde0b7596e1321bfbb76d8192c5ff4">+50/-221</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional support for integrating environment vectors into graph neural network models, allowing enhanced model flexibility for DJMGNN and HMGNN architectures.
  - Force field mapping now exclusively supports OpenMM, with streamlined atom typing and a unified OpenMM XML export.

- **Bug Fixes**
  - Improved validation for angle and dihedral parameters during force field mapping.

- **Tests**
  - Updated and simplified tests to focus on OpenMM export and the new configuration approach, removing multi-format and multi-engine tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->